### PR TITLE
monster: Fix auto-upgrade failing to fetch private ossystems-tools

### DIFF
--- a/hosts/features/required/openssh.nix
+++ b/hosts/features/required/openssh.nix
@@ -19,6 +19,12 @@
     }];
   };
 
+  # Trust github.com's host key system-wide so that outgoing fetches (e.g.
+  # builtins.fetchGit of private repos during nixos-rebuild) don't fail with
+  # "Host key verification failed".
+  programs.ssh.knownHosts."github.com".publicKey =
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl";
+
   # Passwordless sudo when SSH'ing with keys
   security.pam.sshAgentAuth.enable = true;
 }

--- a/hosts/monster/default.nix
+++ b/hosts/monster/default.nix
@@ -10,6 +10,7 @@
     ../features/zram-swap.nix
     ./partitioning.nix
     ./github-runner.nix
+    ./ossystems-tools-access.nix
     ../../users/samuel
   ];
 

--- a/hosts/monster/ossystems-tools-access.nix
+++ b/hosts/monster/ossystems-tools-access.nix
@@ -1,0 +1,25 @@
+{ config, ... }:
+
+# The `ossystems-tools` package is fetched from a private repository over SSH
+# (see pkgs/ossystems-tools/default.nix, `builtins.fetchGit`). This fetch runs
+# at evaluation time as root during `nixos-rebuild`/auto-upgrade, so root needs
+# a deploy key with read access to the repo. The github.com host key is trusted
+# in hosts/features/required/openssh.nix.
+#
+# NOTE: on the very first deploy the secret is not on disk yet (it is only
+# materialised during activation, which happens *after* evaluation). Bootstrap
+# that first switch by providing the key to root manually (copy it to
+# /root/.ssh/id_ed25519 or forward an agent). Every subsequent auto-upgrade
+# then uses the path below.
+{
+  sops.secrets.ossystems-tools-deploy-key = {
+    # Uses sops.defaultSopsFile (secrets/monster.yaml) set in github-runner.nix.
+    mode = "0400";
+  };
+
+  programs.ssh.extraConfig = ''
+    Match host github.com user root
+      IdentityFile ${config.sops.secrets.ossystems-tools-deploy-key.path}
+      IdentitiesOnly yes
+  '';
+}


### PR DESCRIPTION
## Problema

`nixos-upgrade` na `monster` falhava em **todo** switch (logo desde que `ossystems-tools` foi adicionado), com:

```
error: Failed to fetch git repository 'ssh://git@github.com/OSSystems/ossystems-tools.git'
Host key verification failed.
```

`pkgs/ossystems-tools/default.nix` faz `builtins.fetchGit` de um repo **privado** via SSH; isso roda em tempo de eval como **root** durante o auto-upgrade, e o root da box não confiava na host key do github (nem tinha acesso ao repo). Com o build falhando, nenhuma geração nova era aplicada — incluindo os runners e o user `samuel`.

## Correção

- Confia na host key do github.com no sistema (`programs.ssh.knownHosts`).
- Dá ao root uma deploy key via `sops` e aponta o SSH dele pra ela em fetches a `github.com`.

## Follow-up manual (não incluído neste PR)

1. Gerar a deploy key e registrá-la como **Deploy Key (read-only)** em `OSSystems/ossystems-tools`.
2. Adicionar a chave privada em `secrets/monster.yaml` (sops) sob `ossystems-tools-deploy-key`.
3. Bootstrap do primeiro switch na box (o secret só existe em disco após a primeira ativação).