### PR TITLE
monster: Move CI runner work dir off tmpfs onto disk

### DIFF
--- a/nix/hosts/monster/github-runner.nix
+++ b/nix/hosts/monster/github-runner.nix
@@ -36,7 +36,7 @@ in
     trusted-users = runners;
   };
 
-  systemd.tmpfiles.rules = [ "d /var/lib/github-runner-work 0750 root root -" ];
+  systemd.tmpfiles.rules = [ "d /var/lib/github-runner-work 0755 root root -" ];
 
   systemd.mounts = [
     {
@@ -47,7 +47,7 @@ in
       requires = [ "systemd-tmpfiles-setup.service" ];
       after = [ "systemd-tmpfiles-setup.service" ];
       before = map (r: "github-runner-${r}.service") runners;
-      wantedBy = map (r: "github-runner-${r}.service") runners;
+      wantedBy = [ "multi-user.target" ];
     }
   ];
 

--- a/nix/hosts/monster/github-runner.nix
+++ b/nix/hosts/monster/github-runner.nix
@@ -36,6 +36,21 @@ in
     trusted-users = runners;
   };
 
+  systemd.tmpfiles.rules = [ "d /var/lib/github-runner-work 0750 root root -" ];
+
+  systemd.mounts = [
+    {
+      what = "/var/lib/github-runner-work";
+      where = "/run/github-runner";
+      type = "none";
+      options = "bind";
+      requires = [ "systemd-tmpfiles-setup.service" ];
+      after = [ "systemd-tmpfiles-setup.service" ];
+      before = map (r: "github-runner-${r}.service") runners;
+      wantedBy = map (r: "github-runner-${r}.service") runners;
+    }
+  ];
+
   systemd.services = builtins.listToAttrs (
     builtins.map
       (n: {


### PR DESCRIPTION
The srvos github-runner module uses /run (tmpfs) as the runner
HOME/WorkingDirectory, so checkouts and Zephyr/twister builds run in
RAM. monster has 16GB and zram-only swap (no disk fallback), and the
default ~4GB /run is overflowed by a single ~5GB Zephyr build, failing
with ENOSPC.

Bind a disk-backed directory over /run/github-runner so each runner's
RuntimeDirectory is created on ext4 instead. Use systemd.mounts (ordered
after tmpfiles creates the source and before the runners) rather than
fileSystems to avoid a local-fs.target ordering cycle.
